### PR TITLE
ci: install jsonld to build pkgdown website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Suggests:
     wk,
     purrr,
     withr
+Config/Needs/website: jsonld
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
 Depends: 


### PR DESCRIPTION
To fix this error we see in e.g. https://github.com/r-universe/ropensci/actions/runs/10630901334/job/29470737497

```
Caused by error:
! please install the jsonld package to use this functionality.
```